### PR TITLE
Fixed handling of empty strings.

### DIFF
--- a/src/urlon.js
+++ b/src/urlon.js
@@ -26,7 +26,7 @@ URLON = {
 				return '_' + res.join('&') + ';';
 			}
 			// String or undefined
-			return '=' + encodeString((input || "null").toString());
+			return '=' + encodeString((input !== null ? input : "null").toString());
 		}
 
 		return stringify(input).replace(/;+$/g, '');


### PR DESCRIPTION
Empty strings were getting converted to 'null'.  By using the !==
operator, we can explicitly check for null, and empty strings work as
expected.
